### PR TITLE
Rething caching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,6 @@ dependencies = [
  "log 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "tar 0.3.2 (git+https://github.com/dbrgn/tar-rs?branch=pax_header)",
- "tempdir 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ ansi_term = "^0.7"
 log = "^0.3"
 tar = { git = "https://github.com/dbrgn/tar-rs", branch = "pax_header" }
 flate2 = "^0.2"
-tempdir = "^0.3"
 curl = "^0.2"
 env_logger = { version = "^0.3", optional = true }
 rustc-serialize = "^0.3"

--- a/src/main.rs
+++ b/src/main.rs
@@ -161,8 +161,11 @@ fn main() {
         process::exit(1);
     }
 
-    println!("{}", USAGE);
-    process::exit(1);
+    // Some flags can be run without a command.
+    if !args.flag_update {
+        println!("{}", USAGE);
+        process::exit(1);
+    }
 }
 
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -104,7 +104,6 @@ fn main() {
     let args: Args = Docopt::new(USAGE)
                             .and_then(|d| d.decode())
                             .unwrap_or_else(|e| e.exit());
-    println!("{:#?}", args);
 
     // Show version and exit
     if args.flag_version {

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,6 @@ extern crate docopt;
 extern crate ansi_term;
 extern crate flate2;
 extern crate tar;
-extern crate tempdir;
 extern crate curl;
 extern crate rustc_serialize;
 
@@ -120,13 +119,13 @@ fn main() {
     // Update cache, pass through
     if args.flag_update {
         let dl = Updater::new(ARCHIVE_URL);
-        let copied = dl.update().unwrap_or_else(|e| {
+        dl.update().unwrap_or_else(|e| {
             match e {
                 TldrError::UpdateError(msg) => println!("Could not update cache: {}", msg),
             };
             process::exit(1);
         });
-        println!("Cached {} tldr pages.", copied);
+        println!("Successfully updated cache.");
     }
 
     // Render local file and exit

--- a/src/updater.rs
+++ b/src/updater.rs
@@ -1,39 +1,13 @@
 use std::io::Read;
-use std::path::Path;
 use std::fs;
 use std::env;
 
 use flate2::read::GzDecoder;
 use tar::Archive;
 use curl::http;
-use rustc_serialize::json;
 
 use error::TldrError::{self, UpdateError};
 
-
-#[derive(Debug, RustcEncodable, RustcDecodable)]
-struct TldrIndex {
-    commands: Vec<TldrCommand>,
-}
-
-#[derive(Debug, RustcEncodable, RustcDecodable)]
-struct TldrCommand {
-    name: String,
-    platform: Vec<String>,
-}
-
-impl TldrIndex {
-    /// Return vec of all occuring platforms, without duplicates.
-    fn unique_platforms(&self) -> Vec<String> {
-        let mut flattened: Vec<String> = self.commands
-                                             .iter()
-                                             .flat_map(|cmd| cmd.platform.clone())
-                                             .collect();
-        flattened.sort();
-        flattened.dedup();
-        flattened
-    }
-}
 
 #[derive(Debug)]
 pub struct Updater {
@@ -63,48 +37,6 @@ impl Updater {
     fn decompress<R: Read>(&self, reader: R) -> Result<Archive<GzDecoder<R>>, TldrError> {
         let decoder = try!(GzDecoder::new(reader).map_err(|_| UpdateError("Could not decode gzip data".into())));
         Ok(Archive::new(decoder))
-    }
-
-    /// Given the path to the `pages` directory, return `TldrIndex` instances.
-    fn get_index(&self, path: &Path) -> Result<TldrIndex, TldrError> {
-        let mut buffer = String::new();
-        let mut index = try!(fs::File::open(path.join("index.json"))
-            .map_err(|_| UpdateError("Could not open index.json".into())));
-        try!(index.read_to_string(&mut buffer)
-            .map_err(|_| UpdateError("Could not read index.json".into())));
-        let deserialized: TldrIndex = try!(json::decode(&buffer)
-            .map_err(|e| UpdateError(format!("Could not deserialize index.json: {}", e))));
-        Ok(deserialized)
-    }
-
-    /// Copy all pages to the cache. Return the number of copied pages.
-    fn copy_pages(&self, src_dir: &Path, dst_dir: &Path, index: &TldrIndex) -> Result<u64, TldrError> {
-        // Make sure all platform directories exist
-        for platform in &index.unique_platforms() {
-            debug!("Ensure platform directory {:?} exists", &dst_dir.join(platform));
-            try!(fs::create_dir_all(&dst_dir.join(platform)).map_err(|e| {
-                UpdateError(format!("Could not create platform directory: {}", e))
-            }));
-        }
-
-        let mut copied = 0u64;
-        for page in &index.commands {
-            for platform in &page.platform {
-                let relpath = Path::new(&platform).join(format!("{}.md", &page.name));
-                let bytes = fs::copy(&src_dir.join(&relpath), &dst_dir.join(&relpath)).unwrap_or_else(|e| {
-                    debug!("Could not copy {:?} to {:?}: {}",
-                           &src_dir.join(&relpath), &dst_dir.join(&relpath), e);
-                    println!("Warning: Could not copy the tldr page for the \"{}\" command.", &page.name);
-                    0u64
-                });
-                if bytes > 0 {
-                    copied += 1;
-                };
-            }
-        };
-
-        debug!("Copied {} pages to {:?}", copied, &dst_dir);
-        Ok(copied)
     }
 
     /// Update the pages cache. Return the number of cached pages.


### PR DESCRIPTION
Right now I'm trying to follow the caching conventions used by the node client (main directory ~/.tldr/cache`, containing `LICENSE.md` and the `pages/` directory).

The problem is that this convention is not written down anywhere. If the two clients make different decisions, we could end up overwriting the cache of each other.

I thought about proposing a standard, but in the end it's probably the easiest if we simply dump the git export into our own cache (following the XDG standard at `~/.cache/tldr-rs` for POSIX systems). We could either dump the files into that directory directly, or alternatively put them into a `checkout` subdir.

The huge advantage of this is that we can scrap the `index.json` file [which is unreliable](https://github.com/tldr-pages/tldr/issues/487) and get rid of a lot of complicated code targeted at deserializing that file and copying the pages to the cache.

Instead, our own cache would probably make more sense, and it will always be up to date. And during the cache rebuilding, we could also drop commands not supported by the current architecture.