### PR TITLE
Support {{ }} syntax in formatter

### DIFF
--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -2,10 +2,26 @@
 
 use std::io::BufRead;
 
-use ansi_term::Colour;
+use ansi_term::{Colour, ANSIStrings};
 
 use tokenizer::Tokenizer;
 use types::LineType;
+
+
+/// Provide formatting for {{ curly braces }} in ExampleCode lines
+fn format_braces(text: &str) -> String {
+    let parts = text.split("{{").flat_map(|s| s.split("}}"))
+                    .enumerate()
+                    .map(|(i, v)| {
+                        if i % 2 == 0 {
+                            Colour::Cyan.paint(v)
+                        } else {
+                            Colour::Cyan.underline().paint(v)
+                        }
+                    })
+                    .collect::<Vec<_>>();
+    return ANSIStrings(&parts).to_string()
+}
 
 /// Print a token stream to an ANSI terminal.
 pub fn print_lines<R>(tokenizer: &mut Tokenizer<R>) where R: BufRead {
@@ -15,7 +31,7 @@ pub fn print_lines<R>(tokenizer: &mut Tokenizer<R>) where R: BufRead {
             LineType::Title(_) => debug!("Ignoring title"),
             LineType::Description(text) => println!("  {}", text),
             LineType::ExampleText(text) => println!("  {}", Colour::Green.paint(format!("- {}", text))),
-            LineType::ExampleCode(text) => println!("  {}", Colour::Cyan.paint(format!("  {}", text))),
+            LineType::ExampleCode(text) => println!("  {}", &format_braces(&text)),
             LineType::Other(text) => debug!("Unknown line type: {:?}", text),
         }
     }


### PR DESCRIPTION
Right now, tar output looks like this:

```
  - create a gzipped archive

    tar czf {{target.tar.gz}} {{file1 file2 file3}}
```